### PR TITLE
Fix a blank `onOff` causing Leaflet 1.0 maps to stop responding to all event handlers

### DIFF
--- a/dist/Control.Dumb.js
+++ b/dist/Control.Dumb.js
@@ -18,7 +18,10 @@ exports.default = _leaflet.Control.extend({
   },
 
   onRemove: function onRemove(map) {
-    map.off(this.options.onOff, this.options.handleOff, this);
+    if (this.options.onOff) {
+      map.off(this.options.onOff, this.options.handleOff, this);
+    }
+
     return this;
   }
 });

--- a/dist/control.js
+++ b/dist/control.js
@@ -36,7 +36,7 @@ var Control = function (_MapControl) {
   function Control(props) {
     _classCallCheck(this, Control);
 
-    return _possibleConstructorReturn(this, Object.getPrototypeOf(Control).call(this, props));
+    return _possibleConstructorReturn(this, (Control.__proto__ || Object.getPrototypeOf(Control)).call(this, props));
   }
 
   _createClass(Control, [{
@@ -54,13 +54,13 @@ var Control = function (_MapControl) {
   }, {
     key: 'componentDidMount',
     value: function componentDidMount() {
-      _get(Object.getPrototypeOf(Control.prototype), 'componentDidMount', this).call(this);
+      _get(Control.prototype.__proto__ || Object.getPrototypeOf(Control.prototype), 'componentDidMount', this).call(this);
       this.renderContent();
     }
   }, {
     key: 'componentDidUpdate',
     value: function componentDidUpdate(next) {
-      _get(Object.getPrototypeOf(Control.prototype), 'componentDidUpdate', this).call(this, next);
+      _get(Control.prototype.__proto__ || Object.getPrototypeOf(Control.prototype), 'componentDidUpdate', this).call(this, next);
       this.renderContent();
     }
   }, {

--- a/lib/Control.Dumb.js
+++ b/lib/Control.Dumb.js
@@ -6,13 +6,16 @@ export default Control.extend({
     onOff: '',
     handleOff: function noop(){}
   },
-  
+
   onAdd: function (map) {
     return DomUtil.create('div', this.options.className);
   },
-  
+
   onRemove: function (map) {
-    map.off(this.options.onOff, this.options.handleOff, this);
+    if (this.options.onOff) {
+        map.off(this.options.onOff, this.options.handleOff, this);
+    }
+
     return this;
   }
 });


### PR DESCRIPTION
On Leaflet 1.0, adding a control and then removing it from the map causes the map to stop responding to event handlers. This breaks zooming tile layers, makes vector layers go all weird, and generally breaks the map. See #4 

This PR adds a quick check to make sure that `options.onOff` is actually defined to be something (and not `''`). This check works around the aforementioned bug. However, I have not tested to see if this bug exists when `options.onOff` is defined, but this works for when `options.onOff = ''`.
