### PR TITLE
Disable click propagation on control component

### DIFF
--- a/dist/Control.Dumb.js
+++ b/dist/Control.Dumb.js
@@ -13,8 +13,10 @@ exports.default = _leaflet.Control.extend({
     handleOff: function noop() {}
   },
 
-  onAdd: function onAdd(map) {
-    return _leaflet.DomUtil.create('div', this.options.className);
+  onAdd: function (map) {
+    var _controlDiv = _leaflet.DomUtil.create('div', this.options.className);
+    _leaflet.DomEvent.disableClickPropagation(_controlDiv);
+    return _controlDiv;
   },
 
   onRemove: function onRemove(map) {

--- a/lib/Control.Dumb.js
+++ b/lib/Control.Dumb.js
@@ -1,4 +1,4 @@
-import { Control, DomUtil } from 'leaflet';
+import { Control, DomUtil, DomEvent } from 'leaflet';
 
 export default Control.extend({
   options: {
@@ -8,7 +8,9 @@ export default Control.extend({
   },
 
   onAdd: function (map) {
-    return DomUtil.create('div', this.options.className);
+    var _controlDiv = DomUtil.create('div', this.options.className);
+    DomEvent.disableClickPropagation(_controlDiv);
+    return _controlDiv;
   },
 
   onRemove: function (map) {


### PR DESCRIPTION
Hi! Thanks again for creating and maintaining this library. I was setting up a sandbox project using this component and encountered a bug whereby clicks (and double clicks) on the control component pass through to the map and can cause the map to pan or zoom when the user's trying to click on the control. 

You can see the bug in action in this small demo project I set up: 

https://github.com/kellyi/react-container/tree/research/react-leaflet-control-bug

![screen shot 2016-11-28 at 8 46 29 pm](https://cloud.githubusercontent.com/assets/4165523/20693370/f3210678-b5ab-11e6-9bdb-48da9ec2c22c.png)

...in which double clicking on the "Demo Control" component causes the map to zoom. I noticed it when trying to add some buttons to a control and seeing clicks rapid enough in succession to register as double clicks would zoom in on the map.

I did some investigation and noticed that for custom controls Leaflet seems to require explicitly calling `DomEvent.disableClickPropagation(...)` with the custom control as an argument in order to get that behavior: https://github.com/Leaflet/Leaflet/issues/1343#issuecomment-99494636

This PR updates the `onAdd` methods for the `dist` and `lib` `Control.Dumb.js` files to explicitly disable click propagation.

**Testing Instructions**
To test that this works you can:
- check out this project, and instead of following the Docker setup instructions just run

```
cd app
npm install
npm start
```

...with a recent (4.x/6.x) version of Node. The app will load in webpack-dev-server on port 7171, and you can double click on the "Demo Control" text to see the bug happening
- manually edit the `dist/Control.Dumb.js` file in the project's `node_modules` dir to replace the `onAdd` method with:

```js
onAdd: function (map) {
    var _controlDiv = _leaflet.DomUtil.create('div', this.options.className);
    _leaflet.DomEvent.disableClickPropagation(_controlDiv);
    return _controlDiv;
},
```

Webpack-dev-server should patch the change into the project and hot-reload the app in the browser. From there you can try double-clicking on the "Demo Control" text and verify that instead of zooming in on the map, it is highlighting the text instead:

![screen shot 2016-11-28 at 8 55 04 pm](https://cloud.githubusercontent.com/assets/4165523/20693529/f4f9a864-b5ac-11e6-8462-67d294f5664b.png)

Thanks again for maintaining this project! Let me know if you'd like me to make any additional changes or anything for this PR.