### PR TITLE
Update React & React-DOM peer dependency versions to allow ^16.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "license": "ISC",
   "peerDependencies": {
     "leaflet": "^0.7.7 || ^1.0.2",
-    "react": "^0.14.7 || ^15.0.0",
-    "react-dom": "^0.14.7 || ^15.0.0",
+    "react": "^0.14.7 || ^15.0.0 || ^16.0.0",
+    "react-dom": "^0.14.7 || ^15.0.0 || ^16.0.0",
     "react-leaflet": "^0.11.5 || ^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi!

This PR updates the list of allowable React/React-DOM peer dependencies to include `^16.0.0`. Previously using that version of React would result in a warning message while installing this library via Yarn.

To test it, you can update a `package.json` file which includes this library (and uses React 16+) to pull it from:

```json
"react-leaflet-control": "github:kellyi/react-leaflet-control#c4f61a6b43250526c139f125d469623f2dd80c99",
```

...and then `npm install` or `yarn`. The module installation step should no longer display a warning message related to an incorrect peer dependency, and the rest of the library should still work as before.

Thanks again for maintaining this library!

Closes #19 