### PR TITLE
Fixes #21

### DIFF
--- a/lib/control.jsx
+++ b/lib/control.jsx
@@ -37,6 +37,7 @@ export default class Control extends MapControl {
 
   componentWillUnmount() {
     unmountComponentAtNode(this.leafletElement.getContainer());
+    this.leafletElement.remove();
   }
 
   renderContent() {


### PR DESCRIPTION
This PR closes #21 by adding suggested snippet to proper clean unmounting.

Without this fix, a new empty control is generated in every rerendering.