### PR TITLE
Fix initial rendering by forcing a render on mount

### DIFF
--- a/lib/control.jsx
+++ b/lib/control.jsx
@@ -30,6 +30,16 @@ export default withLeaflet(
       return new DumbControl(Object.assign({}, props));
     }
 
+    componentDidMount() {
+      super.componentDidMount();
+
+      // This is needed because the control is only attached to the map in
+      // MapControl's componentDidMount, so the container is not available
+      // until this is called. We need to now force a render so that the
+      // portal and children are actually rendered.
+      this.forceUpdate();
+    }
+
     render() {
       if (!this.leafletElement || !this.leafletElement.getContainer()) {
         return null;


### PR DESCRIPTION
Fix #27 

The reason this bug happens is because `MapControl` only attaches the control to the map in `componentDidMount` - https://github.com/PaulLeCam/react-leaflet/blob/master/src/MapControl.js#L29, so on initial render the container is null. This means that the order of events is 

constructor -> createLeafletEvent -> initial render -> componentDidMount -> onAdd 

Since no prop or state changed after onAdd, the component will not render. This can be fixed by calling `forceUpdate` in `componentDidMount`. It is not particularly elegant, and we are breaking abstraction somewhat, but I don't really see any better way to fix this. 

Demo: https://codesandbox.io/s/pwn65knkzx  